### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ result = m.send_email(data)
 puts result
 ```
 
-##Recommendation:
+## Recommendation:
 
 Sendinblue Ruby GEM has been upgraded to new version 2.4 with object-based wrapper & have new way of sending input parameters & return JSON Object in response.
 


### PR DESCRIPTION
The lack of the space between the hashes and the actual header prevented the GitHub markdown engine from rendering the line as header.